### PR TITLE
Custom prefix config

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This script is meant to be used with [Husky](https://github.com/typicode/husky) 
 Each time you commit, it extracts the issue identifier or user-story identifier from the current branch name and prefixes your commit message with the extracted identifier.
 
 It supports identifiers of the form `ABCD-1234` and `1234`, and will look for such identifiers right after the `/` in the name of the current branch.
-If you're on the branch `feature/JIRA-874-cannot-login-on-macos`, for example, this hook will prefix each of your commit messages with `[ JIRA-874 ] `.
+If you're on the branch `feature/JIRA-874-cannot-login-on-macos`, for example, this hook will prefix each of your commit messages with `[ JIRA-874 ]`.
 
 There are simpler shell scripts that achieve the same, but this solution works on Windows too.
 
@@ -31,3 +31,13 @@ Finally, add the following to `package.json`:
     }
   }
 ```
+
+## Custom prefix
+
+Pass JS snippet (which will be evaluated during the runtime) in single quotes as configuration param to override default prefix structure:
+
+For example:
+
+"prepare-commit-msg": "prefix-commit-message '`${identifier}` '"
+
+Will produce commit message: `JIRA-874 cannot-login-on-macos`

--- a/cli.js
+++ b/cli.js
@@ -16,7 +16,9 @@ while (!isRepositoryRoot(repositoryRoot) && fs.existsSync(repositoryRoot)) {
 }
 
 if (!fs.existsSync(repositoryRoot)) {
-  console.error(`${scriptName} was unable to find the root of the Git repository.`);
+  console.error(
+    `${scriptName} was unable to find the root of the Git repository.`
+  );
   process.exit(1);
 }
 
@@ -43,20 +45,31 @@ if (!identifier) {
 
 const huskyGitParams = process.env.HUSKY_GIT_PARAMS;
 if (!huskyGitParams) {
-  console.error(`${scriptName} expects Git parameters to be accessible via HUSKY_GIT_PARAMS.`);
+  console.error(
+    `${scriptName} expects Git parameters to be accessible via HUSKY_GIT_PARAMS.`
+  );
   process.exit(1);
 }
 
 const commitMessageFile = huskyGitParams.split(" ")[0];
 if (!commitMessageFile) {
-  console.error(`${scriptName} requires HUSKY_GIT_PARAMS to contain the name of the file containing the commit log message.`);
+  console.error(
+    `${scriptName} requires HUSKY_GIT_PARAMS to contain the name of the file containing the commit log message.`
+  );
   process.exit(1);
 }
 
-const pathToCommitMessageFile = path.resolve(path.join(repositoryRoot, commitMessageFile));
+const pathToCommitMessageFile = path.resolve(
+  path.join(repositoryRoot, commitMessageFile)
+);
 
 const content = fs.readFileSync(pathToCommitMessageFile);
-const prefix = "[ " + identifier + " ] ";
+
+let prefix = "[ " + identifier + " ] ";
+
+if (process.argv[2]) {
+  prefix = eval(process.argv[2]);
+}
 
 if (content.indexOf(prefix) === -1) {
   fs.writeFileSync(pathToCommitMessageFile, prefix + content);


### PR DESCRIPTION
Extend functionality by adding ability to customize the prefix:

C/P from Readme:

## Custom prefix

Pass JS snippet (which will be evaluated during the runtime) in single quotes as configuration param to override default prefix structure:

For example:

"prepare-commit-msg": "prefix-commit-message '`${identifier}` '"

Will produce commit message: `JIRA-874 cannot-login-on-macos`